### PR TITLE
Added observe and stopObserving functionality.

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -6,10 +6,10 @@
    } else {
       root.Observer = cls();
    }
-}(this, function() {   
-	
+}(this, function() {
+
    "use strict";
-	
+
    /**
     * Pub/Sub library that allows 'subscribe', 'publish' and 'unsubscribe' methods. 
     *
@@ -31,7 +31,7 @@
     * @type {Boolean}
     */
    Observer.prototype._eventsShouldBubble = false;
-   
+
    /**
     * Whether events should events bubble up to parent.
     *
@@ -43,7 +43,7 @@
       this._eventsShouldBubble = true;
       return this;
    };
-   
+
    /**
     * Get all possible events that can bubble from a given eventName.
     * @param {String} eventName - eventName to split on ':' and return all possible events to bubble.
@@ -54,7 +54,7 @@
          return eventArr.slice(0, index + 1).join(':');
       });
    };
-   
+
    /**
     * Lazy getter for topics.
     * @return {Object}
@@ -65,7 +65,7 @@
       }
       return this._topics;
    };
-   
+
    /**
     * Private method to publish an event. 
     * @param {String} eventName - event to publish.
@@ -90,7 +90,7 @@
             }
          }
       }
-   
+
       return this._eventsShouldBubble;
    };
 
@@ -106,8 +106,8 @@
     * @return {Observer} 'this' for chaining.
     */
    Observer.prototype.subscribe = function(eventName, handler, scope, once) {
-       eventName = (eventName && typeof eventName.toString === 'function') ? 
-                        eventName.toString() : eventName; 
+       eventName = (eventName && typeof eventName.toString === 'function') ?
+                        eventName.toString() : eventName;
                         
       if (typeof handler !== 'function') {
          throw new Error('Observer.subscribe: please provide a function as the handler argument.');
@@ -123,7 +123,7 @@
          scope: scope,
          once: !!once
       });
-   
+
       return this;
    };
 
@@ -136,9 +136,9 @@
     * @param {Object} [scope] - optional scope to unsubscribe from.
     * @return {Observer} 'this' for chaining.
     */
-   Observer.prototype.unsubscribe = function(eventName, scope) {  
-      eventName = (eventName && typeof eventName.toString === 'function') ? 
-                        eventName.toString() : eventName; 
+   Observer.prototype.unsubscribe = function(eventName, scope) {
+      eventName = (eventName && typeof eventName.toString === 'function') ?
+                        eventName.toString() : eventName;
       var topics = this._getTopics();
       [].concat(eventName || Object.keys(topics)).forEach(function(matchedEvent) {
          var topic = topics[matchedEvent];
@@ -148,13 +148,13 @@
                   return observer;
                }
             });
-         
+
             if (!this.hasListeners(matchedEvent)) {
                delete topics[matchedEvent];
             }
          }
       }, this);
-   
+
       return this;
    };
 
@@ -168,9 +168,9 @@
     * @return {Observer} 'this' for chaining.
     */
    Observer.prototype.publish = function(eventName) {
-      eventName = (eventName && typeof eventName.toString === 'function') ? 
-                        eventName.toString() : eventName; 
-   
+      eventName = (eventName && typeof eventName.toString === 'function') ?
+                        eventName.toString() : eventName;
+
       var eventsToPublish = this._getBubbleEvents(eventName),
          args = Array.prototype.slice.call(arguments, 1),
          eventArgs;
@@ -183,7 +183,7 @@
          }
          eventsToPublish.pop();
       }
-   
+
       return this;
    };
 
@@ -230,7 +230,7 @@
 
       return this;
     };
-   
+
    /**
     * Utility to check whether a given event has any listeners; if none is supplied then all topics are checked.
     *
@@ -247,7 +247,7 @@
          return !!Object.keys(topics).length;
       }
    };
-   
+
    /**
     * Static method for using Observer as a mixin.
     *
@@ -265,9 +265,9 @@
          if (props.hasOwnProperty(prop)) {
             base[prop] = props[prop];
           }
-      }	  
+      }
       return base;
    };
-   
+
    return Observer;
 }));

--- a/src/observer.js
+++ b/src/observer.js
@@ -28,6 +28,11 @@
    Observer.prototype._topics = null;
 
    /**
+    * @type {Observer[]}
+    */
+   Observer.prototype._observing = null;
+
+   /**
     * @type {Boolean}
     */
    Observer.prototype._eventsShouldBubble = false;
@@ -186,11 +191,6 @@
 
       return this;
    };
-
-   /**
-    * @type {Array}
-    */
-   Observer.prototype._observing = null;
 
    /**
     * @method observe

--- a/src/observer.js
+++ b/src/observer.js
@@ -205,7 +205,7 @@
          if (this._observing === null) {
             this._observing = [];
          }
-         if (this._observing.filter(function(observed) { return observed === other; }).length === 0) {
+         if (this._observing.indexOf(other) === -1) {
             this._observing.push(other);
          }
          other.subscribe(eventName, handler, this);

--- a/src/observer.js
+++ b/src/observer.js
@@ -201,7 +201,7 @@
     * @return {Observer} 'this' for chaining.
     */
    Observer.prototype.observe = function(other, eventName, handler) {
-      if (other && typeof other.subscribe === 'function') {
+      if (other instanceof Observer) {
          if (this._observing === null) {
             this._observing = [];
          }
@@ -210,7 +210,7 @@
          }
          other.subscribe(eventName, handler, this);
       } else {
-         throw new Error('Observer.observe: please provide an object with a subscribe function as the "other" argument.');
+         throw new Error('Observer.observe: please provide an instance of Observer as the "other" argument.');
       }
 
       return this;

--- a/src/observer.js
+++ b/src/observer.js
@@ -186,6 +186,50 @@
    
       return this;
    };
+
+   /**
+    * @type {Array}
+    */
+   Observer.prototype._observing = null;
+
+   /**
+    * @method observe
+    * @chainable
+    * @param {Observer} other - another object that is an instance of observer that this object will observe.
+    * @param {String|Object} eventName - event to subscribe to, can be joined via ':'.
+    * @param {Function} handler - function to invoke when event is published.
+    * @return {Observer} 'this' for chaining.
+    */
+   Observer.prototype.observe = function(other, eventName, handler) {
+      if (other && typeof other.subscribe === 'function') {
+         if (this._observing === null) {
+            this._observing = [];
+         }
+         if (this._observing.filter(function(observed) { return observed === other; }).length === 0) {
+            this._observing.push(other);
+         }
+         other.subscribe(eventName, handler, this);
+      } else {
+         throw new Error('Observer.observe: please provide an object with a subscribe function as the "other" argument.');
+      }
+
+      return this;
+   };
+
+   /**
+    * @method stopObserving
+    * @chainable
+    * @return {Observer} 'this' for chaining.
+    */
+    Observer.prototype.stopObserving = function() {
+      if (Array.isArray(this._observing)) {
+         this._observing.forEach(function(other) {
+            other.unsubscribe(null, this);
+         }, this);
+      }
+
+      return this;
+    };
    
    /**
     * Utility to check whether a given event has any listeners; if none is supplied then all topics are checked.

--- a/test/observerTest.js
+++ b/test/observerTest.js
@@ -85,6 +85,43 @@ describe('ObserverTest', function(){
        observer.publish('foo');
        expect(spy).toHaveBeenCalled();
    });
+
+   it('can observe another object', function() {
+      var spy = jasmine.createSpy();
+
+      var another = new Observer();
+
+      observer.observe(another, 'foo', spy);
+      another.publish('foo');
+      expect(spy).toHaveBeenCalled();
+   });
+
+   it('can stop observing another object', function() {
+      var spy = jasmine.createSpy();
+
+      var another = new Observer();
+
+      observer.observe(another, 'foo', spy);
+      observer.stopObserving();
+      another.publish('foo');
+      expect(spy.callCount).toBe(0);
+   });
+
+   it('can stop observing multiple objects', function() {
+      var spy = jasmine.createSpy();
+      var secondSpy = jasmine.createSpy();
+
+      var another = new Observer();
+      var yetAnother = new Observer();
+
+      observer.observe(another, 'foo', spy);
+      observer.observe(yetAnother, 'foo', secondSpy);
+      observer.stopObserving();
+      another.publish('foo');
+      yetAnother.publish('foo');
+      expect(spy.callCount).toBe(0);
+      expect(secondSpy.callCount).toBe(0);
+   });
    
    it('correctly returns if it has listeners', function(){
        var spy = jasmine.createSpy();


### PR DESCRIPTION
The 'observe' and 'stopObserving' methods allow an observer to keep track of all its subscriptions to other event emitters (objects implementing subscribe and unsubscribe) and provide the ability to stop observing in one go. Useful when destroying an object.
